### PR TITLE
Insere fecha-parêntese em rotation no Card Principal

### DIFF
--- a/src/app/theme/components/card-principal/card-principal.component.ts
+++ b/src/app/theme/components/card-principal/card-principal.component.ts
@@ -32,7 +32,7 @@ export class CardPrincipalComponent {
     const rotation =
       currentVariation === EnumVariation.HIGHER
         ? 'rotate(180 8.5 5.5)'
-        : 'rotate(0 8.5 5.5';
+        : 'rotate(0 8.5 5.5)';
 
     const fill =
       currentVariation !== EnumVariation.HIGHER ? '#FF7474' : '#A3FCB6';


### PR DESCRIPTION
Insere o fecha-parêntese `)` que estava faltando no método de rotação usado para modificar as setas de temperatura _maior_ ou _menor_.

Acaba por resolver um problema que passou despercebido:

A seta maior não estava rotacionando.

Como o último dado retornado pela NASA ainda não mudou, e apenas o último Card é analisado nessa questão de flags, a seta sempre apontava _para baixo_ e isso não foi notado, pois _por um acaso_ ela coincide com a seta certa (temperatura menor que o dia anterior, flag _LOWER_).

Eu testei invertendo a lógica e até mesmo usando um ângulo de grau diferente no rotation, mas sem esse `)` realmente não funciona.

Eu percebi isso devido a um warning no devtools.

![image](https://github.com/aLiviaMs/orion-bootcamp-front-alpha-orionis/assets/8779528/e4b63398-ebc1-4f2a-b628-19fd7785c21c)
