### PR TITLE
Configura ambiente de produção e build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,12 +37,12 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "10mb"
+                  "maximumError": "1mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "200kb",
-                  "maximumError": "10mb"
+                  "maximumWarning": "100kb",
+                  "maximumError": "200kb"
                 }
               ],
               "fileReplacements": [

--- a/angular.json
+++ b/angular.json
@@ -37,12 +37,12 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "10mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "200kb",
+                  "maximumError": "10mb"
                 }
               ],
               "fileReplacements": [

--- a/angular.json
+++ b/angular.json
@@ -45,6 +45,12 @@
                   "maximumError": "4kb"
                 }
               ],
+              "fileReplacements": [
+                {
+                  "replace": "src/app/environments/environment.ts",
+                  "with": "src/app/environments/environment.prod.ts"
+                }
+              ],
               "outputHashing": "all"
             },
             "development": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0",
+    "start:prod": "ng serve --host 0.0.0.0 --configuration production",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "npm run lint",

--- a/src/app/core/api/base.api.ts
+++ b/src/app/core/api/base.api.ts
@@ -17,6 +17,7 @@ export class BaseAPI {
       language: 'pt-br',
       ...(bearerToken && { authorization: `Bearer ${bearerToken}` }),
       'Content-Type': 'application/json',
+      'ngrok-skip-browser-warning': 'true',
     };
 
     return headers;

--- a/src/app/environments/environment.prod.ts
+++ b/src/app/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-    production: true,
-  };
+  production: true,
+  apiUrl: 'https://civil-completely-marten.ngrok-free.app',
+};


### PR DESCRIPTION
Com esta configuração, é possível hospedar o projeto na Vercel em versão de produção. Não é necessária nenhuma configuração adicional nessa hospedagem, o padrão pré-definido já builda em modo de produção.

Eu criei uma `apiUrl` específica para produção que usa o serviço do ngrok. A url do back não muda, ela é estática.

Também criei um script `start:prod` para que seja possível testar o ambiente de produção de antemão localmente.

OBS: o ngrok exige que um header de nome `ngrok-skip-browser-warning` seja passado para cada requisição feita ao back que é utilizado nesse serviço. Essa é uma limitação do plano free.