### PR TITLE
Reverte as cores das setas para as originais no Card Principal

### DIFF
--- a/src/app/theme/components/card-principal/card-principal.component.ts
+++ b/src/app/theme/components/card-principal/card-principal.component.ts
@@ -35,7 +35,7 @@ export class CardPrincipalComponent {
         : 'rotate(0 8.5 5.5';
 
     const fill =
-      currentVariation !== EnumVariation.HIGHER ? '#FF7474' : '#A3FCB6';
+      currentVariation !== EnumVariation.HIGHER ? '#A3FCB6' : '#FF7474';
 
     const height = currentVariation !== EnumVariation.HIGHER ? '35px' : '17px';
     const width = currentVariation !== EnumVariation.HIGHER ? '25px' : '17px';


### PR DESCRIPTION
Eu conversei com o P.O. Paulo Reis e ele me confirmou que as setas estão com as cores invertidas.

O design no Figma indica que o _vermelho_ deve ser usado para temperaturas _maiores_, e o documento dispõe explicitamente sobre essas cores. [^1]

Ademais, faz mais sentido o vermelho representar uma temperatura mais quente e o verde o contrário.

Card do Trello associado:
https://trello.com/c/UMjIXSVJ

[^1]: Juntamente às temperaturas deverá aparecer um indicador sendo uma seta **vermelha para cima** caso a temperatura em questão seja **maior** do que a do dia anterior e uma seta **verde para baixo** caso a temperatura tenha diminuído.