### PR TITLE
Remove isVerified

### DIFF
--- a/src/app/auth/sign-up/sign-up.component.ts
+++ b/src/app/auth/sign-up/sign-up.component.ts
@@ -115,14 +115,13 @@ export class SignUpComponent {
       password,
       confirmPassword,
       isSubscribed: newsletterCheckbox,
-      isVerified: false,
     };
     return userData;
   }
 
   /**
    * Responsável por enviar o request com um JSON do tipo IRegisterRequest
-   * Que contem, email(string), password(string), confirmPassword(string), isSubscribed(bool) e isVerified(bool)
+   * Que contem, email(string), password(string), confirmPassword(string) e isSubscribed(bool)
    */
   protected newUserBtnRequest(): void {
     const userData = this.createRequestJson();

--- a/src/app/core/models/iRegisterRequest.ts
+++ b/src/app/core/models/iRegisterRequest.ts
@@ -3,5 +3,4 @@ export interface IRegisterRequestBody {
   password: string;
   confirmPassword: string;
   isSubscribed: boolean;
-  isVerified: boolean;
 }


### PR DESCRIPTION
Essa propriedade já foi removida do Back e da documentação.

_isVerified_ só é manipulado pelo Back (mediante token de verificação de e-mail) e não está mais pedindo isso na requisição.

Já testei o fluxo de registro e verificação. Nada é afetado.