### PR TITLE
Fix: Volta ao login quando fecha dialog em Unsubscribe

### DIFF
--- a/src/app/auth/unsubscribe/unsubscribe.component.ts
+++ b/src/app/auth/unsubscribe/unsubscribe.component.ts
@@ -54,7 +54,10 @@ export class UnsubscribeComponent implements OnInit {
           title: 'Sucesso',
           message: response.data.message,
           feedback: 'success',
-          onClick: () => this.goBack()
+        })
+        .afterClosed()
+        .subscribe(() => {
+          this.goBack();
         });
       })
       .catch((error) => {
@@ -62,7 +65,10 @@ export class UnsubscribeComponent implements OnInit {
           title: 'Falha!',
           message: error,
           feedback: 'error',
-          onClick: () => this.goBack()
+        })
+        .afterClosed()
+        .subscribe(() => {
+          this.goBack();
         });
       })
       .finally(() => {


### PR DESCRIPTION
Implementado Observer que monitora o evento de fechar o dialog (tanto pelo botão _finalizar_ quanto pelo ícone `X` de fechar) e executa o retorno ao login, tanto em caso de sucesso quanto em caso de erro.